### PR TITLE
[ops.tweet] Introducing per tweet list min_score threshold for server side filtering

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,6 +19,11 @@ TWITTER_API_KEY_SECRET=
 TWITTER_ACCESS_TOKEN=
 TWITTER_ACCESS_TOKEN_SECRET=
 
+# Format: listname1:min_score1[,listname2:min_score2, ...]
+# Example: AI:4.5,Life:4,Game:5
+# Default: 4
+## TWITTER_FILTER_MIN_SCORES=
+
 # Milvus database
 MILVUS_HOST=milvus-standalone
 

--- a/src/ops_article.py
+++ b/src/ops_article.py
@@ -138,7 +138,7 @@ class OperatorArticle(OperatorBase):
             content = page["content"]
             source_url = page["source_url"]
             print(f"Summarying page, title: {title}")
-            print(f"Page content ({len(content)} chars): {content}")
+            print(f"Page content ({len(content)} chars): {content[:200]}...")
 
             st = time.time()
 

--- a/src/ops_twitter.py
+++ b/src/ops_twitter.py
@@ -358,7 +358,7 @@ class OperatorTwitter(OperatorBase):
         min_scores_dict: dict = {}
         for data in min_scores:
             list_name = data.split(":")[0]
-            min_score = data.split(":")[1]
+            min_score = float(data.split(":")[1])
 
             min_scores_dict[list_name] = min_score
             print(f"Parsed min_score: list_name: {list_name}, min_score: {min_score}")

--- a/src/ops_twitter.py
+++ b/src/ops_twitter.py
@@ -344,16 +344,29 @@ class OperatorTwitter(OperatorBase):
         print("#####################################################")
         print("# Filter Tweets (After Scoring)")
         print("#####################################################")
-        min_score = kwargs.setdefault("min_score", 3.5)
-        print(f"Min_score: {min_score}")
+        default_min_score = kwargs.setdefault("min_score", 3.5)
+        print(f"Default min_score: {default_min_score}")
 
         # 1. filter all score >= min_score
         filtered = {}
         tot = 0
         cnt = 0
 
+        min_score_param: str = os.getenv("TWITTER_FILTER_MIN_SCORES")
+        min_scores: list = min_score_param.split(",")
+
+        min_scores_dict: dict = {}
+        for data in min_scores:
+            list_name = data.split(":")[0]
+            min_score = data.split(":")[1]
+
+            min_scores_dict[list_name] = min_score
+            print(f"Parsed min_score: list_name: {list_name}, min_score: {min_score}")
+
         for list_name, tweets in pages.items():
             filtered_pages = filtered.setdefault(list_name, [])
+            min_score = min_scores_dict.get(list_name) or default_min_score
+            print(f"Filter list_name: {list_name}, min_score: {min_score}")
 
             for page in tweets:
                 relevant_score = page["__relevant_score"]


### PR DESCRIPTION
Motivation: To reduce noises from Notion inbox, introducing server-side per tweet list `min_score` threshold.

Example in `.env`:
```bash
TWITTER_FILTER_MIN_SCORES=AI:4.5,Life:4,Game:5
```

