### PR TITLE
Fix the splitting for summary and translation

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -157,8 +157,19 @@ def splitSummaryTranslation(text):
 
     summary = res[0].strip()
     translation = ""
-    for i in range(1, len(res)):
-        translation += res[i].strip() + "\n"
+
+    # Notes: the LLM may not reliable to separate chunks, sometimes
+    # the translation maybe separated by \n\n instead of ===
+    chunks = summary.split("\n\n")
+    if len(chunks) > 1:
+        summary = chunks[0]
+
+        for i in range(1, len(chunks)):
+            translation += res[i].strip() + "\n"
+
+    if not translation:
+        for i in range(1, len(res)):
+            translation += res[i].strip() + "\n"
 
     return summary, translation
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -162,7 +162,7 @@ def splitSummaryTranslation(text):
     # the translation content may be separated by \n\n instead of ===
     chunks = summary.split("\n\n")
     if len(chunks) > 1:
-        summary = chunks[0]
+        summary = chunks[0].strip()
 
         for i in range(1, len(chunks)):
             translation += chunks[i].strip() + "\n"

--- a/src/utils.py
+++ b/src/utils.py
@@ -158,14 +158,14 @@ def splitSummaryTranslation(text):
     summary = res[0].strip()
     translation = ""
 
-    # Notes: the LLM may not reliable to separate chunks, sometimes
-    # the translation maybe separated by \n\n instead of ===
+    # Notes: LLM may not be reliable for separating chunks, sometimes
+    # the translation content may be separated by \n\n instead of ===
     chunks = summary.split("\n\n")
     if len(chunks) > 1:
         summary = chunks[0]
 
         for i in range(1, len(chunks)):
-            translation += res[i].strip() + "\n"
+            translation += chunks[i].strip() + "\n"
 
     if not translation:
         for i in range(1, len(res)):


### PR DESCRIPTION
LLM may not be reliable for separating chunks, sometimes
the translation content may be separated by `\n\n` instead of `===`