### PR TITLE
Add env option for YouTube transcript languages

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,11 @@ TWITTER_ACCESS_TOKEN_SECRET=
 # Default: 4
 ## TWITTER_FILTER_MIN_SCORES=
 
+# Format: lang1[,lang2,...]
+# Example: en
+# Default: en
+## YOUTUBE_TRANSCRIPT_LANGS=
+
 # Milvus database
 MILVUS_HOST=milvus-standalone
 

--- a/src/llm_agent.py
+++ b/src/llm_agent.py
@@ -278,7 +278,7 @@ class LLMAgentSummary(LLMAgentBase):
         chunk_size = chunk_size or int(os.getenv("TEXT_CHUNK_SIZE", 2048))
         chunk_overlap = chunk_overlap or int(os.getenv("TEXT_CHUNK_OVERLAP", 256))
 
-        print(f"[LLM] input text ({len(text)} chars), chunk_size: {chunk_size}, chunk_overlap: {chunk_overlap}")
+        print(f"[LLM] input text ({len(text)} chars), chunk_size: {chunk_size}, chunk_overlap: {chunk_overlap}, text: {text:200}")
 
         if not text:
             print("[LLM] Empty input text, return empty summary")

--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -38,7 +38,8 @@ class OperatorYoutube(OperatorBase):
         audio2text=True
     ):
         loader = LLMYoutubeLoader()
-        langs = ["en", "zh", "zh-CN", "zh-Hans", "zh-Hant", "zh-TW"]
+        transcript_langs = os.getenv("YOUTUBE_TRANSCRIPT_LANGS", "en")
+        langs = transcript_langs.split(",")
         print(f"Loading Youtube transcript, supported language list: {langs}")
 
         docs = []


### PR DESCRIPTION
Use env option `YOUTUBE_TRANSCRIPT_LANGS` to specify the accepted transcript languages
- Default: `en`
- Example: `en,zh`
