### PR TITLE
[Journal] Create empty journal note if no input notes

### DIFF
--- a/src/notion.py
+++ b/src/notion.py
@@ -1614,7 +1614,7 @@ class NotionAgent:
         for todo, todo_trans in zip(todo_list, todo_list_trans):
             i += 1
 
-            if not todo.strip():
+            if not todo.strip() or todo.strip() == "n/a":
                 continue
 
             # Skip header if possible

--- a/src/ops_base.py
+++ b/src/ops_base.py
@@ -218,6 +218,10 @@ class OperatorBase:
         db_client=None
     ):
         print(f"[updateCreatedTime] last_created_time: {last_created_time}")
+        if not last_created_time:
+            print("No last_created_time, skip updating")
+            return
+
         client = db_client or DBClient()
 
         curr_created_time = client.get_notion_inbox_created_time(source, list_name)

--- a/src/ops_journal.py
+++ b/src/ops_journal.py
@@ -111,6 +111,8 @@ class OperatorJournal(OperatorBase):
             content += f"{page['title']} {page['content']}" + "\n"
             last_created_time = page["created_time"]
 
+        print(f"Journal input content: {content}")
+
         if not content:
             return [{
                 "name": f"{today}",

--- a/src/ops_journal.py
+++ b/src/ops_journal.py
@@ -111,6 +111,18 @@ class OperatorJournal(OperatorBase):
             content += f"{page['title']} {page['content']}" + "\n"
             last_created_time = page["created_time"]
 
+        if not content:
+            return [{
+                "name": f"{today}",
+                "source": "Journal",
+                "last_created_time": last_created_time,
+                "text": "",
+                "translation": "",
+                "title": f"{today} n/a",
+                "todo": "n/a",
+                "translation_todo": "n/a",
+            }]
+
         llm_response = llm_agent.run(content)
         print(f"Refine content llm response: {llm_response}")
 

--- a/src/ops_journal.py
+++ b/src/ops_journal.py
@@ -111,7 +111,7 @@ class OperatorJournal(OperatorBase):
             content += f"{page['title']} {page['content']}" + "\n"
             last_created_time = page["created_time"]
 
-        print(f"Journal input content: {content}")
+        print(f"Journal input content: [{content}]")
 
         if not content:
             return [{


### PR DESCRIPTION
### Description:
When no journal input notes, LLM will generate a `hallucination` output

![image](https://github.com/finaldie/auto-news/assets/1088543/72339676-bf87-44e4-97fd-7ff371d36ee9)


### Fix
When no journal input notes, create an empty journal note for that day 

![image](https://github.com/finaldie/auto-news/assets/1088543/9649c87d-513b-44fc-b4fe-b9b7af4ac570)
