### PR TITLE
[docker] Upgrade airflow to 2.7.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.3-python3.11
+FROM apache/airflow:2.7.1-python3.11
 
 # keep them same as docker-compose volume path
 VOLUME /opt/airflow

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,7 +18,7 @@ deploy-code:
 deploy-airflow: deploy-code
 	@echo "Assembling Airflow ..."
 	mkdir -p $(AIRFLOW_PROJ_DIR)
-	cd $(AIRFLOW_PROJ_DIR) && mkdir -p dags logs plugins run data
+	cd $(AIRFLOW_PROJ_DIR) && mkdir -p dags logs config plugins run data
 	cd $(AIRFLOW_PROJ_DIR) && chmod 777 run/ data/
 	@echo "Airflow deployment finished"
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -80,6 +80,7 @@ x-airflow-common:
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
+    - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
     - ${AIRFLOW_PROJ_DIR:-.}/run:/opt/airflow/run
     - ${AIRFLOW_PROJ_DIR:-.}/data:/opt/airflow/data
@@ -283,13 +284,14 @@ services:
           echo "   https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#before-you-begin"
           echo
         fi
-        mkdir -p /sources/logs /sources/dags /sources/plugins
-        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,plugins}
+        mkdir -p /sources/logs /sources/dags /sources/config /sources/plugins
+        chown -R "${AIRFLOW_UID}:0" /sources/{logs,dags,config,plugins}
         exec /entrypoint airflow version
     # yamllint enable rule:line-length
     environment:
       <<: *airflow-common-env
       _AIRFLOW_DB_UPGRADE: 'true'
+      _AIRFLOW_DB_MIGRATE: 'true'
       _AIRFLOW_WWW_USER_CREATE: 'true'
       _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}


### PR DESCRIPTION
Major changes:
- Upgrade [Airflow](https://github.com/apache/airflow) from `2.6.3` to `2.7.1`


Migration steps:
- git pull
- make stop && make deploy && make start