### PR TITLE
[Youtube] Robust inbox pages pulling

### DIFF
--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -84,39 +84,43 @@ class OperatorYoutube(OperatorBase):
                 # Notes: some app (e.g. From iOS) will only fill the title
                 # with the url link, it wont fill other fields
                 source_url = page["source_url"] or title
-                print(f"Pulling youtube transcript, title: {title}, page_id: {page_id}, source_url: {source_url}")
+                print(f"[Pulling youtube transcript]: title: {title}, page_id: {page_id}, source_url: {source_url}")
 
-                transcript, metadata = utils.load_video_transcript(
-                    source_url,  # video
-                    source_url,  # audio
-                    page_id=page_id,
-                    data_folder=data_folder,
-                    run_id=run_id)
+                try:
+                    transcript, metadata = utils.load_video_transcript(
+                        source_url,  # video
+                        source_url,  # audio
+                        page_id=page_id,
+                        data_folder=data_folder,
+                        run_id=run_id)
 
-                print(f"Pulled youtube transcipt, metadata: {metadata}")
+                    print(f"Pulled youtube transcipt, metadata: {metadata}")
 
-                page["__transcript"] = transcript
+                    page["__transcript"] = transcript
 
-                page["__title"] = metadata.setdefault("title", "")
-                page["__description"] = metadata.setdefault("description", "")
-                page["__thumbnail_url"] = metadata.setdefault("thumbnail_url", "")
-                page["__publish_date"] = ""
-                if metadata.get("publish_date"):
-                    # Notes: pd is datetime object or str
-                    pd = metadata["publish_date"]
+                    page["__title"] = metadata.setdefault("title", "")
+                    page["__description"] = metadata.setdefault("description", "")
+                    page["__thumbnail_url"] = metadata.setdefault("thumbnail_url", "")
+                    page["__publish_date"] = ""
+                    if metadata.get("publish_date"):
+                        # Notes: pd is datetime object or str
+                        pd = metadata["publish_date"]
 
-                    if isinstance(pd, str):
-                        page["__publish_date"] = pd
+                        if isinstance(pd, str):
+                            page["__publish_date"] = pd
 
-                    else:
-                        pd_pdt = pd.astimezone(pytz.timezone('America/Los_Angeles'))
-                        page["__publish_date"] = pd_pdt.isoformat()
+                        else:
+                            pd_pdt = pd.astimezone(pytz.timezone('America/Los_Angeles'))
+                            page["__publish_date"] = pd_pdt.isoformat()
 
-                page["__author"] = metadata.setdefault("author", "")
-                page["__view_count"] = metadata.setdefault("view_count", 0)
+                    page["__author"] = metadata.setdefault("author", "")
+                    page["__view_count"] = metadata.setdefault("view_count", 0)
 
-                # unit: second
-                page["__length"] = metadata.setdefault("length", 0)
+                    # unit: second
+                    page["__length"] = metadata.setdefault("length", 0)
+
+                except Exception as e:
+                    print(f"[ERROR] Exception occurred during pulling Youtube video: {title}, page_id: {page_id}, source_url: {source_url}")
 
             pages.update(extracted_pages)
 

--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -119,10 +119,10 @@ class OperatorYoutube(OperatorBase):
                     # unit: second
                     page["__length"] = metadata.setdefault("length", 0)
 
+                    pages.update(extracted_pages)
+
                 except Exception as e:
                     print(f"[ERROR] Exception occurred during pulling Youtube video: {title}, page_id: {page_id}, source_url: {source_url} : {e}")
-
-            pages.update(extracted_pages)
 
         return pages
 

--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -84,7 +84,7 @@ class OperatorYoutube(OperatorBase):
                 # Notes: some app (e.g. From iOS) will only fill the title
                 # with the url link, it wont fill other fields
                 source_url = page["source_url"] or title
-                print(f"[Pulling youtube transcript]: title: {title}, page_id: {page_id}, source_url: {source_url}")
+                print(f"====== [Pulling youtube transcript]: title: {title}, page_id: {page_id}, source_url: {source_url} ======")
 
                 try:
                     transcript, metadata = utils.load_video_transcript(

--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -78,7 +78,8 @@ class OperatorYoutube(OperatorBase):
             # - title
             # - video url
             # Pull transcipt and merge it
-            for page_id, page in extracted_pages.items():
+            for page_id, extracted_page in extracted_pages.items():
+                page = copy.deepcopy(extracted_page)
                 title = page["title"]
 
                 # Notes: some app (e.g. From iOS) will only fill the title
@@ -119,7 +120,8 @@ class OperatorYoutube(OperatorBase):
                     # unit: second
                     page["__length"] = metadata.setdefault("length", 0)
 
-                    pages.update(extracted_pages)
+                    pages[page_id] = page
+                    print(f"Page pulled succeed, title {title}, source_url: {source_url}")
 
                 except Exception as e:
                     print(f"[ERROR] Exception occurred during pulling Youtube video: {title}, page_id: {page_id}, source_url: {source_url} : {e}")

--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -168,9 +168,11 @@ class OperatorYoutube(OperatorBase):
         for page in pages:
             title = page["title"]
             page_id = page["id"]
+            print(f"====== Summarying page, title: {title} ======")
+
             content = page["__transcript"]
             source_url = page["source_url"]
-            print(f"Summarying page, title: {title}, source_url: {source_url}")
+            print(f"Summarying page, source_url: {source_url}")
             print(f"Page content ({len(content)} chars): {content[:200]}...")
 
             st = time.time()

--- a/src/ops_youtube.py
+++ b/src/ops_youtube.py
@@ -120,7 +120,7 @@ class OperatorYoutube(OperatorBase):
                     page["__length"] = metadata.setdefault("length", 0)
 
                 except Exception as e:
-                    print(f"[ERROR] Exception occurred during pulling Youtube video: {title}, page_id: {page_id}, source_url: {source_url}")
+                    print(f"[ERROR] Exception occurred during pulling Youtube video: {title}, page_id: {page_id}, source_url: {source_url} : {e}")
 
             pages.update(extracted_pages)
 


### PR DESCRIPTION
# Major changes:
- For non-Youtube video pages (maybe wrongly put there), simply ignore.

## Error messages:
```bash
[2023-09-26, 17:36:54 PDT] {subprocess.py:93} INFO - [utils.load_video_transcript] cannot find cached transcript, will load it from original video, url: https://tidyfirst.substack.com/p/measuring-developer-productivity?ref=refind, page_id: 49b9b073-a14d-40e9-b573-234c130d9455
[2023-09-26, 17:36:54 PDT] {subprocess.py:93} INFO - Loading Youtube transcript with language en ...
[2023-09-26, 17:36:54 PDT] {subprocess.py:93} INFO - [WARN] LLMYoutubeLoader load transcript failed: Could not determine the video ID for the URL https://tidyfirst.substack.com/p/measuring-developer-productivity?ref=refind
[2023-09-26, 17:36:54 PDT] {subprocess.py:93} INFO - Loading Youtube transcript with language zh ...
[2023-09-26, 17:36:54 PDT] {subprocess.py:93} INFO - [WARN] LLMYoutubeLoader load transcript failed: Could not determine the video ID for the URL https://tidyfirst.substack.com/p/measuring-developer-productivity?ref=refind
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - ERROR: [Substack] measuring-developer-productivity: Page type "newsletter" is not supported; please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - /home/***/.local/lib/python3.11/site-packages/whisper/transcribe.py:114: UserWarning: FP16 is not supported on CPU; using FP32 instead
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   warnings.warn("FP16 is not supported on CPU; using FP32 instead")
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - Traceback (most recent call last):
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/home/***/.local/lib/python3.11/site-packages/whisper/audio.py", line 59, in load_audio
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     out = run(cmd, capture_output=True, check=True).stdout
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/usr/local/lib/python3.11/subprocess.py", line 571, in run
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     raise CalledProcessError(retcode, process.args,
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - subprocess.CalledProcessError: Command '['ffmpeg', '-nostdin', '-threads', '0', '-i', '/opt/***/data/news/manual__2023-09-27T00:36:25.462540+00:00/49b9b073-a14d-40e9-b573-234c130d9455_audio.mp3', '-f', 's16le', '-ac', '1', '-acodec', 'pcm_s16le', '-ar', '16000', '-']' returned non-zero exit status 1.
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - 
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - The above exception was the direct cause of the following exception:
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - 
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - Traceback (most recent call last):
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/opt/***/run/auto-news/src/utils.py", line 248, in prun
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     return func()
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -            ^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/opt/***/run/auto-news/src/af_pull.py", line 88, in run
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     return op.pull(data_folder=args.data_folder, run_id=args.run_id)
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/opt/***/run/auto-news/src/ops_youtube.py", line 89, in pull
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     transcript, metadata = utils.load_video_transcript(
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/opt/***/run/auto-news/src/utils.py", line 350, in load_video_transcript
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     audio_text = op_a2t.transcribe(audio_file)
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/opt/***/run/auto-news/src/ops_audio2text.py", line 33, in transcribe
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     text = self.model.transcribe(audio_file)
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/home/***/.local/lib/python3.11/site-packages/whisper/transcribe.py", line 121, in transcribe
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     mel = log_mel_spectrogram(audio, padding=N_SAMPLES)
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/home/***/.local/lib/python3.11/site-packages/whisper/audio.py", line 140, in log_mel_spectrogram
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     audio = load_audio(audio)
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -             ^^^^^^^^^^^^^^^^^
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   File "/home/***/.local/lib/python3.11/site-packages/whisper/audio.py", line 61, in load_audio
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -     raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - RuntimeError: Failed to load audio: ffmpeg version 4.3.6-0+deb11u1 Copyright (c) 2000-2023 the FFmpeg developers
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   built with gcc 10 (Debian 10.2.1-6)
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   configuration: --prefix=/usr --extra-version=0+deb11u1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librabbitmq --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-pocketsphinx --enable-libmfx --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libavutil      56. 51.100 / 56. 51.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libavcodec     58. 91.100 / 58. 91.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libavformat    58. 45.100 / 58. 45.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libavdevice    58. 10.100 / 58. 10.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libavfilter     7. 85.100 /  7. 85.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libavresample   4.  0.  0 /  4.  0.  0
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libswscale      5.  7.100 /  5.  7.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libswresample   3.  7.100 /  3.  7.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO -   libpostproc    55.  7.100 / 55.  7.100
[2023-09-26, 17:36:58 PDT] {subprocess.py:93} INFO - /opt/***/data/news/manual__2023-09-27T00:36:25.462540+00:00/49b9b073-a14d-40e9-b573-234c130d9455_audio.mp3: No such file or directory

```

## Tests
```bash
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - #####################################################
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - # Stats
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - #####################################################
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - Article:
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_input: 1
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_deduping: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_scoring: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_filtering: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_summary: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_ranking: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_pushed: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - YouTube:
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_input: 20
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_deduping: 19
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_scoring: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_filtering: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_summary: 19
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_ranking: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_pushed: 19
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - RSS:
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_input: 33
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_deduping: 1
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_scoring: 1
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_filtering: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_summary: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_ranking: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_pushed: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO - Reddit:
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  AI
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_input: 75
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_deduping: 44
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_scoring: 44
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_filtering: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_summary: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - post_ranking: 0
[2023-09-26, 21:25:57 PDT] {subprocess.py:93} INFO -  - total_pushed: 0
[2023-09-26, 21:25:59 PDT] {subprocess.py:97} INFO - Command exited with return code 0
[2023-09-26, 21:25:59 PDT] {taskinstance.py:1398} INFO - Marking task as SUCCESS. dag_id=news_pulling, task_id=save, execution_date=20230927T041659, start_date=20230927T041857, end_date=20230927T042559
[2023-09-26, 21:25:59 PDT] {local_task_job_runner.py:228} INFO - Task exited with return code 0
[2023-09-26, 21:25:59 PDT] {taskinstance.py:2776} INFO - 1 downstream tasks scheduled from follow-on schedule check
```


# Upgrading Instructions
```bash
make upgrade && make stop && make start
```