### PR TITLE
[notion] Create ToRead database with default options 1-5 for 'User Rating' column

### DIFF
--- a/src/notion.py
+++ b/src/notion.py
@@ -2153,7 +2153,30 @@ class NotionAgent:
                 "last_edited_time": {}
             },
             "User Rating": {
-                "select": {}
+                "select": {
+                    "options": [
+                        {
+                            "name": "1",
+                            "color": "red"
+                        },
+                        {
+                            "name": "2",
+                            "color": "blue"
+                        },
+                        {
+                            "name": "3",
+                            "color": "green"
+                        },
+                        {
+                            "name": "4",
+                            "color": "orange"
+                        },
+                        {
+                            "name": "5",
+                            "color": "yellow"
+                        }
+                    ]
+                }
             },
             "Relevant Score": {
                 "number": {}


### PR DESCRIPTION
Major changes:
- When initial `ToRead` database, create `1` to `5` default options for the `User Rating` column, so users don't bother to create them again. (Notes: users are still able to update/delete anytime by themselves)

![image](https://github.com/finaldie/auto-news/assets/1088543/56843568-ff17-495b-952f-ea3f2de46a8f)
 
