### PR TITLE
Update TODO DAG default interval

### DIFF
--- a/dags/todo.py
+++ b/dags/todo.py
@@ -41,7 +41,7 @@ with DAG(
     max_active_runs=1,
     description='TODO DAG, collect and generate TODOs from takeaways and Journal. config: {"targets": "notion"}',
     # schedule_interval=timedelta(minutes=60),
-    schedule_interval="*/30 * * * *",  # Every 30 minutes
+    schedule_interval="*/60 * * * *",  # Every 60 minutes
     # schedule_interval=None,
     start_date=days_ago(1),
     tags=['NewsBot'],

--- a/src/llm_prompts.py
+++ b/src/llm_prompts.py
@@ -97,6 +97,7 @@ Generate a concise SEO-optimized 'Title', which is at most eight words for the b
 
 LLM_PROMPT_ACTION_ITEM = """
 Analyze the user input content carefully and generate concise 'Action Items' at most eight words:
+- DO NOT generate 'action item' unless necessary.
 - Please carefully review and avoid generating duplicated 'action items'.
 - If no action items can be found, return "None" as the response.
 

--- a/src/notion.py
+++ b/src/notion.py
@@ -690,6 +690,7 @@ class NotionAgent:
                 # extract user rating (frequent used field)
                 "user_rating": rating_prop["name"] if rating_prop else None,
                 "source": source,
+                "tags": self.extractMultiSelect(page["properties"]["Tags"]),
 
                 "properties": props,
                 "blocks": blocks,


### PR DESCRIPTION
Major changes:
- Update default TODO DAG interval from 30 minutes to 60 minutes
- Update Action Item LLM prompts

Upgrade instructions:
- make init