### PR TITLE
[Notion] Fix compatibility for the latest notion-client 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Yuzhang Hu
+Copyright (c) 2023-2024 Yuzhang Hu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/notion.py
+++ b/src/notion.py
@@ -1918,7 +1918,7 @@ class NotionAgent:
             }
         }
 
-        return self.createPage(parent, props, None)
+        return self.createPage(parent, props, [])
 
     def createPage(self, parent, props, blocks):
         new_page = self.api.pages.create(


### PR DESCRIPTION
Ref: #51 

# Fixes
- Fix the compatibility issue for the latest notion: The previous version notion-client 2.0.0 accepted None parameter for children, the latest version 2.2.1 will pass-through and notion backend will return errors. Pass empty array for the case which will compatible with all the versions. e.g.


api.pages.create(
      parent=parent,
      properties=props,
      children=~~None~~[])


# Upgrading Instructions
- For new users, if failed to deploy, remove `workspace` folder, then `make deps && make deploy && make init && make start`
- For old users, no actions.
