### PR TITLE
[Embedding] EmbeddingAgent 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,7 +27,9 @@ GOOGLE_API_KEY=
 # Notes: Currently openai is the only option, will have more options
 # (e.g. google, huggingface, etc) later
 EMBEDDING_PROVIDER=openai
-EMBEDDING_MODEL=text-embedding-ada-002
+
+# models: text-embedding-ada-002, text-embedding-3-small
+EMBEDDING_MODEL=text-embedding-3-small
 
 TEXT_CHUNK_SIZE=10240
 TEXT_CHUNK_OVERLAP=256

--- a/.env.template
+++ b/.env.template
@@ -29,7 +29,7 @@ GOOGLE_API_KEY=
 EMBEDDING_PROVIDER=openai
 
 # models: text-embedding-ada-002, text-embedding-3-small
-EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_MODEL=text-embedding-ada-002
 
 TEXT_CHUNK_SIZE=10240
 TEXT_CHUNK_OVERLAP=256

--- a/.env.template
+++ b/.env.template
@@ -23,9 +23,8 @@ OPENAI_API_KEY=
 GOOGLE_MODEL=gemini-pro
 GOOGLE_API_KEY=
 
-# The generic Text embedding provider.
-# Notes: Currently openai is the only option, will have more options
-# (e.g. google, huggingface, etc) later
+# The generic Text embedding provider. Supported providers:
+# openai, hf, hf_inst
 EMBEDDING_PROVIDER=openai
 
 # models: text-embedding-ada-002, text-embedding-3-small

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A personal news aggregator to pull information from multi-sources + LLM (ChatGPT
 ## Why need it?
 In the world of this information explosion, we live with noise every day, it becomes even worse after the generative AI was born. Time is a precious resource for each of us, How to use our time more efficiently? It becomes more challenging than ever. Think about how much time we spent on pulling/searching/filtering content from different sources, how many times we put the article/paper or long video as a side tab, but never got a chance to look at, and how much effort to organize the information we have read. We need a better way to get rid of the noises, focus on reading the information efficiently based on our interests, and stay on track with the goals we defined.
 
-See this [Blog post](https://finaldie.com/blog/auto-news-an-automated-news-aggregator-with-llm/) and this [YouTube video](https://www.youtube.com/watch?v=hKFIyfAF4Z4) for more details.
+See this [Blog post](https://finaldie.com/blog/auto-news-an-automated-news-aggregator-with-llm/) and these videos [Introduction](https://www.youtube.com/watch?v=hKFIyfAF4Z4), [Data flows](https://www.youtube.com/watch?v=WAGlnRht8LE) for more details.
 
 https://github.com/finaldie/auto-news/assets/1088543/4387f688-61d3-4270-b5a6-105aa8ee0ea9
 

--- a/src/chromadb_cli.py
+++ b/src/chromadb_cli.py
@@ -27,10 +27,11 @@ class ChromaDB:
 
         if not self.emb_fn:
             openai_api_key = os.getenv("OPENAI_API_KEY", "")
+            model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 
             self.emb_fn = embedding_functions.OpenAIEmbeddingFunction(
                 api_key=openai_api_key,
-                model_name="text-embedding-ada-002"
+                model_name=model_name,
             )
 
         print(f"ChromaDB initialization done, db_path: {db_path}, collection_name: {collection_name}, emb_fn: {emb_fn}")

--- a/src/chromadb_cli.py
+++ b/src/chromadb_cli.py
@@ -27,7 +27,7 @@ class ChromaDB:
 
         if not self.emb_fn:
             openai_api_key = os.getenv("OPENAI_API_KEY", "")
-            model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+            model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-ada-002")
 
             self.emb_fn = embedding_functions.OpenAIEmbeddingFunction(
                 api_key=openai_api_key,

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -38,10 +38,10 @@ OBSIDIAN_INBOX_ITEM_ID = "obsidian_inbox_item_id_{}_{}_{}"
 # ttl: 4 weeks
 EMBEDDING_ITEM_ID = "embedding_item_id_{}_{}_{}"
 
-# key: prefix + source_name + id
+# key: prefix + provider + model_name + source_name + id
 # val: embedding data
 # ttl: 4 weeks
-MILVUS_EMBEDDING_ITEM_ID = "milvus_embedding_item_id_{}_{}"
+MILVUS_EMBEDDING_ITEM_ID = "milvus_embedding_item_id_{}_{}_{}_{}"
 
 # key: prefix + source_name + date + id
 # val: true/false

--- a/src/db_cli.py
+++ b/src/db_cli.py
@@ -103,20 +103,28 @@ class DBClient(DBClientBase):
         key = key_tpl.format(source, provider, item_id)
         self.driver.set(key, embed, **kwargs)
 
-    def get_milvus_embedding_item_id(self, source, item_id):
+    def get_milvus_embedding_item_id(
+        self,
+        provider,
+        model_name,
+        source,
+        item_id
+    ):
         key_tpl = data_model.MILVUS_EMBEDDING_ITEM_ID
-        key = key_tpl.format(source, item_id)
+        key = key_tpl.format(provider, model_name, source, item_id)
         return self.driver.get(key)
 
     def set_milvus_embedding_item_id(
         self,
+        provider,
+        model_name,
         source,
         item_id,
         embed: list,
         **kwargs
     ):
         key_tpl = data_model.MILVUS_EMBEDDING_ITEM_ID
-        key = key_tpl.format(source, item_id)
+        key = key_tpl.format(provider, model_name, source, item_id)
         self.driver.set(key, embed, **kwargs)
 
     def get_milvus_perf_data_item_id(self, source, dt: str, item_id):

--- a/src/embedding_agent.py
+++ b/src/embedding_agent.py
@@ -16,7 +16,7 @@ class EmbeddingAgent:
 
         self.model_name = model_name
         if not self.model_name:
-            self.model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+            self.model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-ada-002")
 
         print(f"[EmbeddingAgent] provider: {self.provider}, model_name: {self.model_name}")
 

--- a/src/embedding_agent.py
+++ b/src/embedding_agent.py
@@ -18,7 +18,7 @@ class EmbeddingAgent:
         if not self.model_name:
             self.model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 
-        print(f"[EmbeddingFactory] provider: {self.provider}, model_name: {self.model_name}")
+        print(f"[EmbeddingAgent] provider: {self.provider}, model_name: {self.model_name}")
 
         self.model = None
 

--- a/src/embedding_agent.py
+++ b/src/embedding_agent.py
@@ -4,7 +4,7 @@ from embedding_hf import EmbeddingHuggingFace
 from embedding_hf_inst import EmbeddingHuggingFaceInstruct
 
 
-class EmbeddingFactory:
+class EmbeddingAgent:
     def __init__(
         self,
         provider="",

--- a/src/embedding_factory.py
+++ b/src/embedding_factory.py
@@ -43,5 +43,5 @@ class EmbeddingFactory:
     def create(self, text: str):
         return self.model.create(text)
 
-    def get_or_create(self, text: str, source="", page_id="", db_client=None):
-        return self.model.get_or_create(text, source, page_id, db_client)
+    def get_or_create(self, text: str, source="", page_id="", db_client=None, key_ttl=86400 * 30):
+        return self.model.get_or_create(text, source, page_id, db_client, key_ttl)

--- a/src/embedding_factory.py
+++ b/src/embedding_factory.py
@@ -7,8 +7,8 @@ from embedding_hf_inst import EmbeddingHuggingFaceInstruct
 class EmbeddingFactory:
     def __init__(
         self,
-        provider,
-        model_name,
+        provider="",
+        model_name="",
     ):
         self.provider = provider
         if not self.provider:

--- a/src/embedding_factory.py
+++ b/src/embedding_factory.py
@@ -15,8 +15,8 @@ class EmbeddingFactory:
             self.provider = os.getenv("EMBEDDING_PROVIDER", "openai")
 
         self.model_name = model_name
-        if not self.mode_name:
-            self.mode_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+        if not self.model_name:
+            self.model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 
         print(f"[EmbeddingFactory] provider: {self.provider}, model_name: {self.model_name}")
 

--- a/src/embedding_factory.py
+++ b/src/embedding_factory.py
@@ -1,0 +1,47 @@
+import os
+from embedding_openai import EmbeddingOpenAI
+from embedding_hf import EmbeddingHuggingFace
+from embedding_hf_inst import EmbeddingHuggingFaceInstruct
+
+
+class EmbeddingFactory:
+    def __init__(
+        self,
+        provider,
+        model_name,
+    ):
+        self.provider = provider
+        if not self.provider:
+            self.provider = os.getenv("EMBEDDING_PROVIDER", "openai")
+
+        self.model_name = model_name
+        if not self.mode_name:
+            self.mode_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+
+        print(f"[EmbeddingFactory] provider: {self.provider}, model_name: {self.model_name}")
+
+        self.model = None
+
+        if self.provider == "openai":
+            self.model = EmbeddingOpenAI(model_name=self.model_name)
+
+        elif self.provider == "all-MiniLM-L6-v2":
+            self.model = EmbeddingHuggingFace(model_name=self.model_name)
+
+        elif self.provider == "hkunlp/instructor-xl":
+            self.model = EmbeddingHuggingFaceInstruct(model_name=self.model_name)
+        else:
+            print(f"[ERROR] Unknown embedding model: {self.model_name}")
+            return None
+
+    def dim(self):
+        return self.model.dim()
+
+    def getname(self, start_date, prefix="news"):
+        return self.model.getname(start_date, prefix)
+
+    def create(self, text: str):
+        return self.model.create(text)
+
+    def get_or_create(self, text: str, source="", page_id="", db_client=None):
+        return self.model.get_or_create(text, source, page_id, db_client)

--- a/src/embedding_hf.py
+++ b/src/embedding_hf.py
@@ -44,14 +44,21 @@ class EmbeddingHuggingFace(Embedding):
         client = db_client or DBClient()
 
         embedding = client.get_embedding_item_id(
-            source, "hf", page_id)
+            "hf",
+            self.model_name,
+            source,
+            page_id)
 
         if not embedding:
             embedding = self.create(text)
 
             # store embedding into redis (ttl = 1 month)
             client.set_embedding_item_id(
-                source, "hf", page_id, json.dumps(embedding),
+                "hf",
+                self.model_name,
+                source,
+                page_id,
+                json.dumps(embedding),
                 expired_time=key_ttl)
 
         else:

--- a/src/embedding_hf_inst.py
+++ b/src/embedding_hf_inst.py
@@ -44,14 +44,21 @@ class EmbeddingHuggingFaceInstruct(Embedding):
         client = db_client or DBClient()
 
         embedding = client.get_embedding_item_id(
-            source, "hf_inst", page_id)
+            "hf_inst",
+            self.model_name,
+            source,
+            page_id)
 
         if not embedding:
             embedding = self.create(text)
 
             # store embedding into redis (ttl = 1 month)
             client.set_embedding_item_id(
-                source, "hf_inst", page_id, json.dumps(embedding),
+                "hf_inst",
+                self.model_name,
+                source,
+                page_id,
+                json.dumps(embedding),
                 expired_time=key_ttl)
 
         else:

--- a/src/embedding_openai.py
+++ b/src/embedding_openai.py
@@ -12,9 +12,9 @@ class EmbeddingOpenAI(Embedding):
         self.instance = None
 
         if openai.__version__ < "1.0.0":
-            self.instance = EmbeddingOpenAI_0x()
+            self.instance = EmbeddingOpenAI_0x(model_name=model_name)
         else:  # >= 1.0.0
-            self.instance = EmbeddingOpenAI_1x()
+            self.instance = EmbeddingOpenAI_1x(model_name=model_name)
 
         print(f"Initialized EmbeddingOpenAI Interface: openai version {openai.__version__}")
 
@@ -23,16 +23,17 @@ class EmbeddingOpenAI(Embedding):
 
     def getname(self, start_date, prefix="news"):
         return self.instance.getname(
-            start_date=start_date, prefix=prefix)
+            start_date=start_date,
+            prefix=prefix)
 
     def create(
         self,
         text: str,
-        model_name="text-embedding-ada-002",
         num_retries=3
     ):
         return self.instance.create(
-            text=text, model_name=model_name, num_retries=num_retries)
+            text=text,
+            num_retries=num_retries)
 
     def get_or_create(
         self,
@@ -43,5 +44,8 @@ class EmbeddingOpenAI(Embedding):
         key_ttl=86400 * 30
     ):
         return self.instance.get_or_create(
-            text=text, source=source, page_id=page_id,
-            db_client=db_client, key_ttl=key_ttl)
+            text=text,
+            source=source,
+            page_id=page_id,
+            db_client=db_client,
+            key_ttl=key_ttl)

--- a/src/embedding_openai.py
+++ b/src/embedding_openai.py
@@ -6,7 +6,7 @@ from embedding_openai_1x import EmbeddingOpenAI_1x
 
 
 class EmbeddingOpenAI(Embedding):
-    def __init__(self, model_name="openai"):
+    def __init__(self, model_name=""):
         super().__init__(model_name)
 
         self.instance = None

--- a/src/embedding_openai_0x.py
+++ b/src/embedding_openai_0x.py
@@ -12,7 +12,7 @@ class EmbeddingOpenAI_0x(Embedding):
     """
     For The implementation for openai < 1.*
     """
-    def __init__(self, model_name="text-embedding-3-small"):
+    def __init__(self, model_name="text-embedding-ada-002"):
         super().__init__(model_name)
         print(f"Initialized EmbeddingOpenAI 0x: {openai.__version__}, model_name: {model_name}")
 

--- a/src/embedding_openai_0x.py
+++ b/src/embedding_openai_0x.py
@@ -12,9 +12,9 @@ class EmbeddingOpenAI_0x(Embedding):
     """
     For The implementation for openai < 1.*
     """
-    def __init__(self, model_name="openai"):
+    def __init__(self, model_name="text-embedding-3-small"):
         super().__init__(model_name)
-        print(f"Initialized EmbeddingOpenAI 0x: {openai.__version__}")
+        print(f"Initialized EmbeddingOpenAI 0x: {openai.__version__}, model_name: {model_name}")
 
     def dim(self):
         return 1536
@@ -25,7 +25,6 @@ class EmbeddingOpenAI_0x(Embedding):
     def create(
         self,
         text: str,
-        model_name="text-embedding-ada-002",
         num_retries=3
     ):
         """
@@ -39,19 +38,23 @@ class EmbeddingOpenAI_0x(Embedding):
                 emb = openai.Embedding.create(
                     input=[text],
                     api_key=api_key,
-                    model=model_name)
+                    model=self.model_name)
 
             except openai.error.RateLimitError as e:
                 print(f"[ERROR] RateLimit error during embedding ({i}/{num_retries}): {e}")
 
                 if i == num_retries:
                     raise
+                else:
+                    time.sleep(1)
 
             except openai.error.APIError as e:
                 print(f"[ERROR] Failed during embedding ({i}/{num_retries}): {e}")
 
                 if i == num_retries:
                     raise
+                else:
+                    time.sleep(1)
 
         return emb["data"][0]["embedding"]
 

--- a/src/embedding_openai_0x.py
+++ b/src/embedding_openai_0x.py
@@ -72,7 +72,10 @@ class EmbeddingOpenAI_0x(Embedding):
         client = db_client or DBClient()
 
         embedding = client.get_milvus_embedding_item_id(
-            source, page_id)
+            "openai",
+            self.model_name,
+            source,
+            page_id)
 
         if not embedding:
             # OpenAI embedding model accept 8k tokens, exceed it will
@@ -84,7 +87,11 @@ class EmbeddingOpenAI_0x(Embedding):
 
             # store embedding into redis (ttl = 1 month)
             client.set_milvus_embedding_item_id(
-                source, page_id, json.dumps(embedding),
+                "openai",
+                self.model_name,
+                source,
+                page_id,
+                json.dumps(embedding),
                 expired_time=key_ttl)
 
         else:

--- a/src/embedding_openai_1x.py
+++ b/src/embedding_openai_1x.py
@@ -83,7 +83,10 @@ class EmbeddingOpenAI_1x(Embedding):
         client = db_client or DBClient()
 
         embedding = client.get_milvus_embedding_item_id(
-            source, page_id)
+            "openai",
+            self.model_name,
+            source,
+            page_id)
 
         if not embedding:
             # OpenAI embedding model accept 8k tokens, exceed it will
@@ -95,7 +98,11 @@ class EmbeddingOpenAI_1x(Embedding):
 
             # store embedding into redis (ttl = 1 month)
             client.set_milvus_embedding_item_id(
-                source, page_id, json.dumps(embedding),
+                "openai",
+                self.model_name,
+                source,
+                page_id,
+                json.dumps(embedding),
                 expired_time=key_ttl)
 
         else:

--- a/src/embedding_openai_1x.py
+++ b/src/embedding_openai_1x.py
@@ -28,21 +28,20 @@ class EmbeddingOpenAI_1x(Embedding):
     def create(
         self,
         text: str,
-        model_name="text-embedding-ada-002",
         num_retries=3
     ):
         """
         It creates the embedding with 1536 dimentions by default
         """
-        retry_wait_time = 10  # seconds to wait
-        error_wait_time = 5   # seconds to wait
+        retry_wait_time = 3  # seconds to wait
+        error_wait_time = 2  # seconds to wait
         emb = None
 
         for i in range(1, num_retries + 1):
             try:
                 emb = self.client.embeddings.create(
                     input=[text],
-                    model=model_name)
+                    model=self.model_name)
 
             except openai.RateLimitError as e:
                 print(f"[ERROR] RateLimitError during embedding ({i}/{num_retries}): {e}")

--- a/src/embedding_openai_1x.py
+++ b/src/embedding_openai_1x.py
@@ -13,7 +13,7 @@ class EmbeddingOpenAI_1x(Embedding):
     """
     For The implementation for openai < 1.*
     """
-    def __init__(self, model_name="openai"):
+    def __init__(self, model_name="text-embedding-ada-002"):
         super().__init__(model_name)
         self.client = OpenAI()
 

--- a/src/ops_milvus.py
+++ b/src/ops_milvus.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 from db_cli import DBClient
 from notion import NotionAgent
 from milvus_cli import MilvusClient
-from embedding_openai import EmbeddingOpenAI
+from embedding_factory import EmbeddingFactory
 import utils
 
 
@@ -131,7 +131,7 @@ class OperatorMilvus:
         # print("# Get relevant Milvus pages")
         # print("#####################################################")
 
-        emb_agent = EmbeddingOpenAI()
+        emb_agent = EmbeddingFactory()
 
         collection_name = emb_agent.getname(start_date)
         print(f"[get_relevant] collection_name: {collection_name}")
@@ -228,7 +228,7 @@ class OperatorMilvus:
 
         client = DBClient()
         notion_agent = NotionAgent()
-        emb_agent = EmbeddingOpenAI()
+        emb_agent = EmbeddingFactory()
         milvus_client = MilvusClient(emb_agent=emb_agent)
 
         collection_name = emb_agent.getname(start_date)

--- a/src/ops_milvus.py
+++ b/src/ops_milvus.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 from db_cli import DBClient
 from notion import NotionAgent
 from milvus_cli import MilvusClient
-from embedding_factory import EmbeddingFactory
+from embedding_agent import EmbeddingAgent
 import utils
 
 
@@ -131,7 +131,7 @@ class OperatorMilvus:
         # print("# Get relevant Milvus pages")
         # print("#####################################################")
 
-        emb_agent = EmbeddingFactory()
+        emb_agent = EmbeddingAgent()
 
         collection_name = emb_agent.getname(start_date)
         print(f"[get_relevant] collection_name: {collection_name}")
@@ -228,7 +228,7 @@ class OperatorMilvus:
 
         client = DBClient()
         notion_agent = NotionAgent()
-        emb_agent = EmbeddingFactory()
+        emb_agent = EmbeddingAgent()
         milvus_client = MilvusClient(emb_agent=emb_agent)
 
         collection_name = emb_agent.getname(start_date)


### PR DESCRIPTION
# Changes
- An EmbeddingAgent to manage/switch according to embedding `provider` and `model_name`
- Refine `Redis` cache key with provider and model_name
- Tune the openai failure retry sleep seconds

# Notes
- Default embedding provider and model name remain as the same, users could change it via the environment vars: `EMBEDDING_PROVIDER` and `EMBEDDING_MODEL`, please see `.env.template` for more details.