### PR TITLE
[ArgoCD] Enable deployment via ArgoCD

### DIFF
--- a/.env.template.k8s
+++ b/.env.template.k8s
@@ -104,13 +104,13 @@ MYSQL_DATABASE=bot
 #########################################
 # Redis options
 #########################################
-BOT_REDIS_URL=redis://:@auto-news-redis:6379/1
+BOT_REDIS_URL=redis://:@auto-news-redis-master-0:6379/1
 BOT_REDIS_KEY_EXPIRE_TIME=604800
 
 #########################################
 # Experimental options
 #########################################
-ACTION_DEEPDIVE_ENABLED=false
+ACTION_DEEPDIVE_ENABLED=true
 ACTION_DEEPDIVE_ITERATIONS=1
 
 # GPT4 Turbo (128k tokens)

--- a/.env.template.k8s
+++ b/.env.template.k8s
@@ -104,7 +104,7 @@ MYSQL_DATABASE=bot
 #########################################
 # Redis options
 #########################################
-BOT_REDIS_URL=redis://:@auto-news-redis-master-0:6379/1
+BOT_REDIS_URL=redis://:@auto-news-redis-master:6379/1
 BOT_REDIS_KEY_EXPIRE_TIME=604800
 
 #########################################

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ help:
 	@echo "\_ make k8s-helm-install"
 	@echo "\_ make k8s-airflow-dags-enable"
 	@echo ""
+	@echo "=== ArgoCD deployment ==="
+	@echo "\_ make k8s-argocd-install"
+	@echo "\_ make k8s-airflow-dags-enable"
+	@echo ""
 	@echo "=== k8s port-fowarding ==="
 	@echo "Airflow: 'kubectl port-forward service/auto-news-webserver 8080:8080 --namespace ${namespace} --address=0.0.0.0'"
 	@echo "Milvus : 'kubectl port-forward service/auto-news-milvus-attu -n ${namespace} 9100:3001 --address=0.0.0.0'"
@@ -239,6 +243,32 @@ airflow-dags-disable:
 	kubectl exec -n ${namespace} auto-news-worker-0 -- airflow dags pause journal_daily
 	kubectl exec -n ${namespace} auto-news-worker-0 -- airflow dags pause action
 	@echo "Airflow DAGs pausing finished"
+
+k8s-argocd-install:
+	@echo "ArgoCD: Installing Auto-News argocd helm chart..."
+	helm upgrade \
+		--install \
+		--debug \
+		--namespace=${namespace} \
+		--create-namespace \
+		--timeout=${TIMEOUT} \
+		--wait=true \
+		argocd-apps-auto-news \
+		./argocd
+	@echo "ArgoCD: Auto-News argocd helm chart installation finished, goto ArgoCD dashboard to check the service deployment status"
+
+# Notes: uninstall argocd helm chart won't uninstall the auto-news
+# services, to uninstall auto-news, click 'Delete' button from ArgoCD
+# dashboard
+k8s-argocd-uninstall:
+	@echo "ArgoCD uninstallation ..."
+	helm uninstall \
+		--ignore-not-found \
+		--wait=true \
+		--namespace=${namespace} \
+		--debug \
+		argocd-apps-auto-news
+
 
 .PHONY: deps build deploy deploy-env init start stop logs clean push_dags
 .PHONY: test upgrade enable_dags info ps help prepare-env docker-network

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,9 @@ k8s-env-create:
 	if [ ! -f $(build_dir)/.env.k8s ]; then \
 		cp .env.template.k8s $(build_dir)/.env.k8s; \
 	fi
-	if [ ! -f $(build_dir)/.env.k8s.docker ]; then \
-		cat $(build_dir)/.env.k8s | grep -vE "NOTION_TOKEN|OPENAI_API_KEY|GOOGLE_API_KEY|REDDIT_CLIENT_ID|REDDIT_CLIENT_SECRET|AUTOGEN_GPT4_API_KEY|AUTOGEN_GPT3_API_KEY|TWITTER_API_KEY|TWITTER_API_KEY_SECRET|TWITTER_ACCESS_TOKEN|TWITTER_ACCESS_TOKEN_SECRET|MYSQL_USER|MYSQL_PASSWORD" > $(build_dir)/.env.k8s.docker; \
-		echo "**env file generating completed (secrets removed):**"; \
-	fi
+	@echo "***Create env file for k8s docker image**"
+	cat $(build_dir)/.env.k8s | grep -vE "NOTION_TOKEN|NOTION_ENTRY_PAGE_ID|OPENAI_API_KEY|GOOGLE_API_KEY|REDDIT_CLIENT_ID|REDDIT_CLIENT_SECRET|AUTOGEN_GPT4_API_KEY|AUTOGEN_GPT3_API_KEY|TWITTER_API_KEY|TWITTER_API_KEY_SECRET|TWITTER_ACCESS_TOKEN|TWITTER_ACCESS_TOKEN_SECRET|MYSQL_USER|MYSQL_PASSWORD" > $(build_dir)/.env.k8s.docker;
+	@echo "**env file generating completed (secrets removed):**";
 	@echo ""
 	cat $(build_dir)/.env.k8s.docker
 	@echo "===="
@@ -178,6 +177,7 @@ k8s-secret-create:
 	-kubectl create secret generic airflow-secrets \
 	-n ${namespace} \
   --from-literal=NOTION_TOKEN=$(NOTION_TOKEN) \
+  --from-literal=NOTION_ENTRY_PAGE_ID=$(NOTION_ENTRY_PAGE_ID) \
   --from-literal=OPENAI_API_KEY=$(OPENAI_API_KEY) \
   --from-literal=GOOGLE_API_KEY=$(GOOGLE_API_KEY) \
   --from-literal=REDDIT_CLIENT_ID=$(REDDIT_CLIENT_ID) \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![GitHub Build](https://github.com/finaldie/auto-news/actions/workflows/python.yml/badge.svg)](https://github.com/finaldie/auto-news/actions)
 ![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=Flat&logo=kubernetes&logoColor=white)
-![Notion](https://img.shields.io/badge/Notion-%23000000.svg?style=Flat&logo=notion&logoColor=white)
 ![ChatGPT](https://img.shields.io/badge/chatGPT-74aa9c?style=Flat&logo=openai&logoColor=white)
+![Notion](https://img.shields.io/badge/Notion-%23000000.svg?style=Flat&logo=notion&logoColor=white)
+https://img.shields.io/badge/Helm-0F1689?style=Flat&logo=Helm&labelColor=0F1689
 
 A personal news aggregator to pull information from multi-sources + LLM (ChatGPT) to help us read efficiently with less noise, the sources including Tweets, RSS, YouTube, Web Articles, Reddit, and random Journal notes.
 
@@ -36,7 +37,7 @@ https://github.com/finaldie/auto-news/wiki
 
 ## Architecture
 * UI: Notion-based, cross-platform (Web browser, iOS/Android app)
-* Backend: Runs on Linxu/MacOS
+* Backend: Runs on Linux/MacOS
   * For deployment: Support both [docker-compose](https://docs.docker.com/compose/) and [kubernetes](https://kubernetes.io/)
 
 ![image](https://github.com/finaldie/auto-news/assets/1088543/d1923ea8-6e4f-46b8-a654-45e21372438e)
@@ -49,6 +50,14 @@ https://github.com/finaldie/auto-news/wiki
 | CPU       | 2 cores              | 8 cores      |
 | Memory    | 6GB                  | 16GB         |
 | Disk      | 20GB                 | 100GB        |
+
+
+# Kubernetes Deployment
+
+See the installation guide from:
+- [Installation using Helm](https://github.com/finaldie/auto-news/wiki/Installation-using-Helm)
+- [Installation using ArgoCD](https://github.com/finaldie/auto-news/wiki/Installation-using-ArgoCD)
+
 
 # Quick Start Guide (Docker-compose)
 ## Preparison
@@ -112,12 +121,8 @@ Go to Notion `ToRead` database page, all the data will flow into this database l
 
 Now, enjoy and have fun.
 
-# Kubernetes Deployment
-
-See the installation guide from: [Installation using Helm](https://github.com/finaldie/auto-news/wiki/Installation-using-Helm)
-
-# Operations
-## [Monitoring] Control Panel
+## Operations
+### [Monitoring] Control Panel
 For troubleshooting, we can use the URLs below to access the services and check the logs and data
 
 | Service | Role            | Panel URL             |
@@ -126,7 +131,7 @@ For troubleshooting, we can use the URLs below to access the services and check 
 | Milvus  | Vector Database | http://localhost:9100 |
 | Adminer | DB accessor     | http://localhost:8070 |
 
-## Stop/Restart Services
+### Stop/Restart Services
 In case we want, apply the following commands from the codebase folder.
 
 ```bash
@@ -137,17 +142,17 @@ make stop
 make stop && make start
 ```
 
-## Redeploy `.env` and DAGs
+### Redeploy `.env` and DAGs
 ```bash
 make stop && make init && make start
 ```
 
-## Upgrade to the latest code
+### Upgrade to the latest code
 ```bash
 make upgrade && make stop && make init && make start
 ```
 
-## Rebuild Docker Images
+### Rebuild Docker Images
 ```bash
 make stop && make build && make init && make start
 ```

--- a/argocd/Chart.yaml
+++ b/argocd/Chart.yaml
@@ -1,0 +1,15 @@
+name: argo-cd apps - auto-news
+description: A Helm Chart for argo-cd apps - auto-news
+version: 1.0.0
+apiVersion: v2
+keywords:
+  - argo-cd
+  - apps
+  - auto-news
+home: https://github.com/finaldie/auto-news
+sources:
+  - https://github.com/finaldie/auto-news
+
+maintainers:
+  - email: hyzwowtools@gmail.com
+    name: Yuzhang Hu

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -1,0 +1,6 @@
+This chart contains:
+- argo-cd apps - auto-news
+
+Install all apps manifests into ArgoCD, ArgoCD will deploy them accordingly:
+- Easy to track different services status and resources
+- Easy to operate sub services

--- a/argocd/templates/app-auto-news.yaml
+++ b/argocd/templates/app-auto-news.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: auto-news
+  namespace: argocd
+spec:
+  destination:
+    namespace: {{ .Release.Namespace }}
+    server: {{ .Values.destination.server }}
+  project: {{ .Values.project }}
+  source:
+    repoURL: {{ .Values.source.repoURL }}
+    path: {{ .Values.source.path }}
+    targetRevision: {{ .Values.source.targetRevision }}
+    helm:
+      valueFiles:
+        - values.yaml
+  {{- if .Values.syncPolicy }}
+  syncPolicy:
+    automated:
+      prune: {{ .Values.syncPolicy.prune }}
+      selfHeal: {{ .Values.syncPolicy.selfHeal }}
+  {{- end }}

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -10,7 +10,7 @@ destination:
   # in-cluster
   server: https://kubernetes.default.svc
 
-# Automated (comment out entire section if disable automation)
-syncPolicy:
-  prune: true
-  selfHeal: true
+## Automated (uncomment below if enable automated sync)
+# syncPolicy:
+#   prune: true
+#   selfHeal: true

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -3,8 +3,7 @@ project: default
 # global vars
 source:
   repoURL: git@github.com:finaldie/auto-news.git
-  # targetRevision: HEAD
-  targetRevision: undo.argocd.init-240401
+  targetRevision: HEAD
   path: helm
 
 destination:

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -3,7 +3,8 @@ project: default
 # global vars
 source:
   repoURL: git@github.com:finaldie/auto-news.git
-  targetRevision: HEAD
+  # targetRevision: HEAD
+  targetRevision: undo.argocd.init-240401
   path: helm
 
 destination:

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -1,0 +1,16 @@
+project: default
+
+# global vars
+source:
+  repoURL: git@github.com:finaldie/auto-news.git
+  targetRevision: HEAD
+  path: helm
+
+destination:
+  # in-cluster
+  server: https://kubernetes.default.svc
+
+# Automated (comment out entire section if disable automation)
+syncPolicy:
+  prune: true
+  selfHeal: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,7 +5,7 @@ airflow:
   images:
     airflow:
       repository: finaldie/auto-news
-      tag: 0.9.4
+      tag: 0.9.5
 
     useDefaultImageForMigration: true
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,7 +5,7 @@ airflow:
   images:
     airflow:
       repository: finaldie/auto-news
-      tag: 0.9.3
+      tag: 0.9.4
 
     useDefaultImageForMigration: true
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -155,17 +155,35 @@ airflow:
 #######################################################################
 redis:
   enabled: true
-  password: bot
 
-  resources:
-  #   limits:
-  #     cpu: 1
-  #     memory: 1Gi
-    requests:
-      cpu: 200m
-      memory: 32Mi
+  # `standalone` or `replication`
+  architecture: standalone
 
-  affinity: {}
+  # Internal use only, no auth
+  auth:
+    enabled: false
+
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+    resources:
+    #   limits:
+    #     cpu: 1
+    #     memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 32Mi
+
+    affinity: {}
+
+  metrics:
+    enabled: true
+
+    # Enable/disable prometheus service monitor
+    serviceMonitor:
+      enabled: false
 
 
 #######################################################################

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,7 +5,7 @@ airflow:
   images:
     airflow:
       repository: finaldie/auto-news
-      tag: 0.9.5
+      tag: 0.9.6
 
     useDefaultImageForMigration: true
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -169,17 +169,22 @@ redis:
       size: 8Gi
 
     resources:
-    #   limits:
-    #     cpu: 1
-    #     memory: 1Gi
+      # limits:
+      #   cpu: 1
+      #   memory: 1Gi
       requests:
-        cpu: 200m
+        cpu: 100m
         memory: 32Mi
 
     affinity: {}
 
   metrics:
     enabled: true
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 32Mi
 
     # Enable/disable prometheus service monitor
     serviceMonitor:

--- a/src/ops_reddit.py
+++ b/src/ops_reddit.py
@@ -351,12 +351,15 @@ class OperatorReddit(OperatorBase):
         tot = 0
         cnt = 0
 
-        min_score_param: str = os.getenv("REDDIT_FILTER_MIN_SCORES")
+        min_score_param: str = os.getenv("REDDIT_FILTER_MIN_SCORES", "")
         min_scores: list = min_score_param.split(",")
         print(f"min_scores: {min_scores}")
 
         min_scores_dict: dict = {}
         for data in min_scores:
+            if not data:
+                continue
+
             print(f"parsing min_score: [{data}]")
 
             if not data or len(data.split(":")) < 2:

--- a/src/ops_twitter.py
+++ b/src/ops_twitter.py
@@ -336,11 +336,14 @@ class OperatorTwitter(OperatorBase):
         tot = 0
         cnt = 0
 
-        min_score_param: str = os.getenv("TWITTER_FILTER_MIN_SCORES")
+        min_score_param: str = os.getenv("TWITTER_FILTER_MIN_SCORES", "")
         min_scores: list = min_score_param.split(",")
 
         min_scores_dict: dict = {}
         for data in min_scores:
+            if not data:
+                continue
+
             print(f"parsing min_score: [{data}]")
 
             if not data or len(data.split(":")) < 2:


### PR DESCRIPTION
# Changes
- [ArgoCD](https://argo-cd.readthedocs.io/en/stable/) deployment
- Robust `ops_reddit`
- Move `NOTION_ENTRY_PAGE_ID` to k8s secret
- Upgrade base image to `0.9.6`
- Tune `Redis` resources to prevent CPU throttling alerts
- Fix `Redis` uri in k8s
- Enable `deepdive` feature by default

