### PR TITLE
[MISC] Update env templates with gpt-4o-mini

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,7 +19,8 @@ NOTION_ENTRY_PAGE_ID=
 # If pick ollama, then use below OLLAMA_MODEL and OLLAMA_URL
 LLM_PROVIDER=openai
 
-OPENAI_MODEL=gpt-3.5-turbo-0125
+# Ref: https://platform.openai.com/docs/models
+OPENAI_MODEL=gpt-4o-mini
 OPENAI_API_KEY=
 # OPENAI_PROXY=
 

--- a/.env.template
+++ b/.env.template
@@ -25,7 +25,7 @@ OPENAI_API_KEY=
 # OPENAI_PROXY=
 
 # gemini-pro | gemini-1.5-flash-latest | ...
-GOOGLE_MODEL=gemini-pro
+GOOGLE_MODEL=gemini-1.5-flash-latest
 GOOGLE_API_KEY=
 
 OLLAMA_MODEL=llama3

--- a/.env.template.k8s
+++ b/.env.template.k8s
@@ -13,13 +13,14 @@ NOTION_ENTRY_PAGE_ID=
 #########################################
 # LLM options
 #########################################
-# The generic LLM provider, E.g. openai, google
+# The generic LLM provider, E.g. openai, google, ollama
 # If pick openai, then use below OPENAI_MODEL and OPENAI_API_KEY
 # If pick google, then use below GOOGLE_MODEL and GOOGLE_API_KEY
 # If pick ollama, then use below OLLAMA_MODEL and OLLAMA_URL
 LLM_PROVIDER=openai
 
-OPENAI_MODEL=gpt-3.5-turbo-0125
+# Ref: https://platform.openai.com/docs/models
+OPENAI_MODEL=gpt-4o-mini
 OPENAI_API_KEY=
 # OPENAI_PROXY=
 

--- a/.env.template.k8s
+++ b/.env.template.k8s
@@ -25,7 +25,7 @@ OPENAI_API_KEY=
 # OPENAI_PROXY=
 
 # gemini-pro | gemini-1.5-flash-latest | ...
-GOOGLE_MODEL=gemini-pro
+GOOGLE_MODEL=gemini-1.5-flash-latest
 GOOGLE_API_KEY=
 
 OLLAMA_MODEL=llama3

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ For more background, see this [Blog post](https://finaldie.com/blog/auto-news-an
 - Generate insights of YouTube videos (Do transcoding if no transcript provided)
 - Generate insights of Web Articles
 - Filter content based on personal interests and remove 80%+ noises
+- Weekly Top-k Recap
 - Unified and central reading experience (RSS reader-like style, Notion-based)
 - Generate `TODO` list from takeaways and journal notes
 - Organize Journal notes with insights daily
 - [Multi-Agents] **Experimental** [Deepdive](https://github.com/finaldie/auto-news/wiki/Deepdive-(Experimental)) topic via web search agent and [autogen](https://github.com/microsoft/autogen)
 - Multi-LLM backend: OpenAI ChatGPT, Google Gemini, Ollama
-- Weekly Top-k Recap
 
 <img src="https://github.com/finaldie/auto-news/assets/1088543/778242a7-5811-49e1-8982-8bd32d141639" width="80%" />
 

--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ For more details, please check out the [App official website](https://dotsfy.com
 The client is using [Notion](https://www.notion.so/), and the backend is fully `self-hosted` by ourselves.
 
 #### Backend System Requirements
-| Component | Minimum Requirements | Recommended  |
-| --------- | -----------          | ----         |
-| OS        | Linux, MacOS         | Linux, MacOS |
-| CPU       | 2 cores              | 8 cores      |
-| Memory    | 6GB                  | 16GB         |
-| Disk      | 20GB                 | 100GB        |
+| Component | Minimum      | Recommended  |
+| --------- | -----------  | ----         |
+| OS        | Linux, MacOS | Linux, MacOS |
+| CPU       | 2 cores      | 8 cores      |
+| Memory    | 6GB          | 16GB         |
+| Disk      | 20GB         | 100GB        |
 
 #### Docker-compose
 - [Installation using Docker-compose](https://github.com/finaldie/auto-news/wiki/Docker-Installation)
+- [Installation using Portainer](https://github.com/finaldie/auto-news/wiki/Installation-using-Portainer)
 
 #### Kubernetes
 - [Installation using Helm](https://github.com/finaldie/auto-news/wiki/Installation-using-Helm)


### PR DESCRIPTION
# Changes
- Update default `env` templates:
  - openai: use `gpt-4o-mini` as the default
  - google: use `gemini-1.5-flash-latest` as the default