### PR TITLE
Fix docker compose deployment

### DIFF
--- a/.github/workflows/docker-compose-deploy.yml
+++ b/.github/workflows/docker-compose-deploy.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker compose deploy (pre-start)
 
 on:
   push:

--- a/.github/workflows/docker-compose-deploy.yml
+++ b/.github/workflows/docker-compose-deploy.yml
@@ -1,0 +1,23 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Docker compose deploy (pre-start)
+      run: |
+        make deps
+        make deploy

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ deploy-airflow:
 deploy-env:
 	cp $(build_dir)/.env $(BOT_HOME)/src
 
-deploy: deploy-airflow deploy-env
+deploy: deploy-airflow
 
 init: deploy-env
 	cd docker && make init topdir=$(topdir)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ deps: prepare-env
 # deps: docker-network
 
 repo ?= finaldie/auto-news
-tag ?= 0.9.10
+tag ?= 0.9.11
 
 build:
 	cd docker && make build repo=$(repo) tag=$(tag) topdir=$(topdir)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -52,7 +52,7 @@ x-airflow-common:
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
   # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.5.2}
-  image: ${AIRFLOW_IMAGE_NAME:-finaldie/auto-news:0.9.10}
+  image: ${AIRFLOW_IMAGE_NAME:-finaldie/auto-news:0.9.11}
   # build: .
 
   networks:

--- a/docker/portainer/docker-compose.yaml
+++ b/docker/portainer/docker-compose.yaml
@@ -52,7 +52,7 @@ x-airflow-common:
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
   # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.5.2}
-  image: ${AIRFLOW_IMAGE_NAME:-finaldie/auto-news:0.9.10}
+  image: ${AIRFLOW_IMAGE_NAME:-finaldie/auto-news:0.9.11}
   # build: .
 
   networks:


### PR DESCRIPTION
# Changes
- Remove deprecated deployment steps
- Upgrade default image to `0.9.11`
- New github workflow for testing docker compose deploy