### PR TITLE
docker: Fix mysql database version

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -364,7 +364,7 @@ services:
         condition: service_completed_successfully
 
   mysql:
-    image: mysql:latest
+    image: mysql:8.4.2
     container_name: mysql-db
     networks:
       - bot_network

--- a/docker/portainer/docker-compose.yaml
+++ b/docker/portainer/docker-compose.yaml
@@ -367,7 +367,7 @@ services:
         condition: service_completed_successfully
 
   mysql:
-    image: mysql:latest
+    image: mysql:8.4.2
     container_name: mysql-db
     networks:
       - bot_network


### PR DESCRIPTION
# Changes
- For Docker (Portainer) environment, the latest MySQL-9 has incompatible with MySQL-8 parameters and prevents the service start, revert and fixes the MySQL version to 8.4.2


# Related Issues
- #90 