### PR TITLE
[docker] Fix docker compose pick env file unreliable issue

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -17,6 +17,8 @@ deploy-airflow:
 	mkdir -p $(AIRFLOW_PROJ_DIR)
 	cd $(AIRFLOW_PROJ_DIR) && mkdir -p dags logs config plugins run data
 	cd $(AIRFLOW_PROJ_DIR) && chmod 777 run/ data/
+	@echo "Copy environment file ..."
+	cp $(topdir)/build/.env $(AIRFLOW_PROJ_DIR)/config
 	@echo "Airflow deployment finished"
 
 deploy-postgres:
@@ -66,7 +68,8 @@ deploy: post-deploy
 init: push_dags copy_files
 
 start-services:
-	docker-compose --env-file ../build/.env up -d
+	echo "Starting services with env file: $(topdir)/build/.env"
+	docker compose --env-file $(topdir)/build/.env up -d
 
 start: start-services
 	@echo ""
@@ -76,27 +79,27 @@ start: start-services
 	@echo "- Adminer: http://`hostname`:8070"
 
 stop:
-	docker-compose down
+	docker compose down
 
 logs:
-	docker-compose logs -n 1000
+	docker compose logs -n 1000
 
 ps:
-	docker-compose ps
+	docker compose ps
 
 info:
-	docker-compose run airflow-cli airflow info
-	docker-compose run airflow-cli airflow dags list
+	docker compose run airflow-cli airflow info
+	docker compose run airflow-cli airflow dags list
 
 upgrade:
-	docker-compose run airflow-cli airflow dags trigger upgrade
+	docker compose run airflow-cli airflow dags trigger upgrade
 
 enable_dags:
-	docker-compose run airflow-cli airflow dags unpause news_pulling
-	docker-compose run airflow-cli airflow dags unpause sync_dist
-	docker-compose run airflow-cli airflow dags unpause collection_weekly
-	docker-compose run airflow-cli airflow dags unpause upgrade
-	docker-compose run airflow-cli airflow dags unpause journal_daily
+	docker compose run airflow-cli airflow dags unpause news_pulling
+	docker compose run airflow-cli airflow dags unpause sync_dist
+	docker compose run airflow-cli airflow dags unpause collection_weekly
+	docker compose run airflow-cli airflow dags unpause upgrade
+	docker compose run airflow-cli airflow dags unpause journal_daily
 
 push_dags:
 	test -d $(AIRFLOW_PROJ_DIR)/dags || mkdir -p $(AIRFLOW_PROJ_DIR)/dags

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -87,9 +87,6 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-./workspace/airflow}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-./workspace/airflow}/plugins:/opt/airflow/plugins
     - ${AIRFLOW_PROJ_DIR:-./workspace/airflow}/data:/opt/airflow/data
-    # - ${OBSIDIAN_DIR:-.}:${OBSIDIAN_DIR}
-    # - /var/run/docker.sock:/var/run/docker.sock
-    # - ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro
   # user: "${AIRFLOW_UID:-50000}:0"
   user: "${AIRFLOW_UID:-0}:0"
   depends_on:
@@ -177,6 +174,9 @@ services:
       - |
         echo "User: `id`"
         echo "PWD: `pwd`"
+        echo "Environment vars:"
+        env
+        echo "----"
         pip install --upgrade pip
         echo "=================================================="
         echo "Upgrade pip packages from requirements-local.txt  "
@@ -189,6 +189,16 @@ services:
           echo "[pip] langchain version (after): `pip list | grep langchain`"
         fi
         pip3 install httpx[socks]
+        echo "=================================================="
+        echo "Picking up environment file "
+        echo "=================================================="
+        if [ -f ~/airflow/config/.env ]; then
+          cp ~/airflow/config/.env ~/airflow/run/auto-news/src
+          echo "Copied environment file to the runtime."
+        else
+          echo "ERROR: Environment file not found, exit"
+          exit 1
+        fi
         echo "=================================================="
         echo "Start airflow worker ...  "
         echo "=================================================="
@@ -317,7 +327,21 @@ services:
         echo "User: `id`"
         echo "PWD: `pwd`"
         echo "----"
+        echo "Env"
+        env
+        echo "=================================================="
+        echo "Picking up environment file "
+        echo "=================================================="
+        if [ -f ~/airflow/config/.env ]; then
+          cp ~/airflow/config/.env ~/airflow/run/auto-news/src
+          echo "Copied environment file to the runtime."
+        else
+          echo "ERROR: Environment file not found, exit"
+          exit 1
+        fi
+        echo "=================================================="
         echo "Apply patches ..."
+        echo "=================================================="
         python3 ~/airflow/run/auto-news/src/patches.py
         echo "Apply patches finished"
         echo "----"


### PR DESCRIPTION
# Changes
- [Fix] Docker compose may not reliable to pick up the env file, workaround to copy the `build/.env` to runtime for `Docker setup`

# Related Issus
- #90 