### PR TITLE
Fix collection embedding names

### DIFF
--- a/src/db_cli.py
+++ b/src/db_cli.py
@@ -86,23 +86,6 @@ class DBClient(DBClientBase):
         key = key_tpl.format(source, category, item_id)
         self.driver.set(key, "true", **kwargs)
 
-    def get_embedding_item_id(self, source, provider, item_id):
-        key_tpl = data_model.EMBEDDING_ITEM_ID
-        key = key_tpl.format(source, provider, item_id)
-        return self.driver.get(key)
-
-    def set_embedding_item_id(
-        self,
-        source,
-        provider,
-        item_id,
-        embed: list,
-        **kwargs
-    ):
-        key_tpl = data_model.EMBEDDING_ITEM_ID
-        key = key_tpl.format(source, provider, item_id)
-        self.driver.set(key, embed, **kwargs)
-
     def get_milvus_embedding_item_id(
         self,
         provider,

--- a/src/embedding.py
+++ b/src/embedding.py
@@ -1,16 +1,23 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+import re
 
 
-class Embedding(ABC):
-    def __init__(self, model_name="openai"):
+class Embedding:
+    def __init__(self, model_name):
         self.model_name = model_name
+
+    def getname(self, start_date, prefix="news"):
+        """
+        Get the name of the milvus collection for the embedding
+        We are only allowed to use alphanumeric characters and underscores in the collection name
+        """
+        # Replace any non-alphanumeric character in the model name with an underscore
+        sanitized_model_name = re.sub(r'\W+', '_', self.model_name)
+        sanitized_start_date = start_date.replace('-', '_')
+        return f"{prefix}_{sanitized_model_name}__{sanitized_start_date}"
 
     @abstractmethod
     def dim(self):
-        pass
-
-    @abstractmethod
-    def getname(self, start_date, prefix="news"):
         pass
 
     @abstractmethod

--- a/src/embedding_hf.py
+++ b/src/embedding_hf.py
@@ -21,9 +21,6 @@ class EmbeddingHuggingFace(Embedding):
     def dim(self):
         return 384
 
-    def getname(self, start_date, prefix="news"):
-        return f"{prefix}_embedding_hf_{start_date}".replace("-", "_")
-
     def create(self, text: str, normalize=True):
         """
         Query local HF embedding model

--- a/src/embedding_hf.py
+++ b/src/embedding_hf.py
@@ -46,7 +46,7 @@ class EmbeddingHuggingFace(Embedding):
         """
         client = db_client or DBClient()
 
-        embedding = client.get_embedding_item_id(
+        embedding = client.get_milvus_embedding_item_id(
             "hf",
             self.model_name,
             source,
@@ -56,7 +56,7 @@ class EmbeddingHuggingFace(Embedding):
             embedding = self.create(text)
 
             # store embedding into redis (ttl = 1 month)
-            client.set_embedding_item_id(
+            client.set_milvus_embedding_item_id(
                 "hf",
                 self.model_name,
                 source,

--- a/src/embedding_hf_inst.py
+++ b/src/embedding_hf_inst.py
@@ -46,7 +46,7 @@ class EmbeddingHuggingFaceInstruct(Embedding):
         """
         client = db_client or DBClient()
 
-        embedding = client.get_embedding_item_id(
+        embedding = client.get_milvus_embedding_item_id(
             "hf_inst",
             self.model_name,
             source,
@@ -56,7 +56,7 @@ class EmbeddingHuggingFaceInstruct(Embedding):
             embedding = self.create(text)
 
             # store embedding into redis (ttl = 1 month)
-            client.set_embedding_item_id(
+            client.set_milvus_embedding_item_id(
                 "hf_inst",
                 self.model_name,
                 source,

--- a/src/embedding_hf_inst.py
+++ b/src/embedding_hf_inst.py
@@ -21,9 +21,6 @@ class EmbeddingHuggingFaceInstruct(Embedding):
     def dim(self):
         return 384
 
-    def getname(self, start_date, prefix="news"):
-        return f"{prefix}_embedding_hf_inst_{start_date}".replace("-", "_")
-
     def create(self, text: str, normalize=True):
         """
         Query local HF embedding model

--- a/src/embedding_ollama.py
+++ b/src/embedding_ollama.py
@@ -35,12 +35,6 @@ class EmbeddingOllama(Embedding):
         self.dimensions = len(query_result)
         return self.dimensions
 
-    def getname(self, start_date, prefix="ollama"):
-        """
-        Get a embedding collection name of milvus
-        """
-        return f"embedding__{prefix}__ollama_{self.model_name}__{start_date}".replace("-", "_")
-
     def create(
         self,
         text: str,

--- a/src/embedding_openai_0x.py
+++ b/src/embedding_openai_0x.py
@@ -21,9 +21,6 @@ class EmbeddingOpenAI_0x(Embedding):
     def dim(self):
         return 1536
 
-    def getname(self, start_date, prefix="news"):
-        return f"{prefix}_embedding__{start_date}".replace("-", "_")
-
     def create(
         self,
         text: str,

--- a/src/embedding_openai_1x.py
+++ b/src/embedding_openai_1x.py
@@ -30,9 +30,6 @@ class EmbeddingOpenAI_1x(Embedding):
     def dim(self):
         return 1536
 
-    def getname(self, start_date, prefix="news"):
-        return f"{prefix}_embedding__{start_date}".replace("-", "_")
-
     def create(
         self,
         text: str,


### PR DESCRIPTION
The original problem was that

```python
f"{prefix}_embedding_hf_{start_date}".replace("-", "_")
```

was not following the convention that two underscores seperate the `start_date`.

This can be easily refactored into the parent class and made more robust by utilizing the `model_name`, so that we never compare vectors between different embedding models and never find ourselves creating a oversight bug like this again.